### PR TITLE
Disable CGO so that we get a static binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/middlenamesfirst/envoy-proxy-controller
 
 COPY . .
 
-RUN go build -a -o /go/bin/envoy-proxy-controller .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/envoy-proxy-controller .
 
 FROM alpine:3.9.3@sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913
 


### PR DESCRIPTION
This disables `CGO` so we end up with a static binary. I followed https://docs.docker.com/develop/develop-images/multistage-build/ and https://medium.com/@diogok/on-golang-static-binaries-cross-compiling-and-plugins-1aed33499671.