### PR TITLE
Add a Dockerfile for the Envoy proxy container image

### DIFF
--- a/docker-envoy-proxy/Dockerfile
+++ b/docker-envoy-proxy/Dockerfile
@@ -1,0 +1,7 @@
+FROM envoyproxy/envoy-alpine:v1.10.0@sha256:930f6e7a1cde805d455683c9e54d452b5a6acc035ec77f86a7d499d6c92785a0
+
+RUN mkdir -p /var/log/envoy
+
+EXPOSE 9901
+
+COPY envoy.yaml /etc/envoy/envoy.yaml

--- a/docker-envoy-proxy/Makefile
+++ b/docker-envoy-proxy/Makefile
@@ -1,0 +1,14 @@
+DOCKER_ORG := middlenamesfirst
+NAME := docker-envoy-proxy
+GIT_COMMIT := $(shell git rev-parse --short=10 HEAD 2>/dev/null)
+
+BASE_IMAGE_URL := $(DOCKER_ORG)/$(NAME)
+IMAGE_URL := $(BASE_IMAGE_URL):$(GIT_COMMIT)
+
+.PHONY: docker-build
+docker-build:
+	docker build --pull -t ${IMAGE_URL} .
+
+.PHONY: docker-run
+docker-run:
+	docker run -d --name envoy -p 9901:9901 ${IMAGE_URL}

--- a/docker-envoy-proxy/envoy.yaml
+++ b/docker-envoy-proxy/envoy.yaml
@@ -1,0 +1,7 @@
+admin:
+  access_log_path: /var/log/envoy/admin_access.log
+  address:
+    socket_address:
+      protocol: TCP
+      address: 0.0.0.0
+      port_value: 9901


### PR DESCRIPTION
To build the image run `make docker-build` and to run the image `make docker-run`:
```
docker-envoy-proxy git:docker-envoy-proxy ❯ make docker-build
docker build --pull -t middlenamesfirst/docker-envoy-proxy:b22fe4cabe .
Sending build context to Docker daemon  4.096kB
Step 1/4 : FROM envoyproxy/envoy-alpine:v1.10.0@sha256:930f6e7a1cde805d455683c9e54d452b5a6acc035ec77f86a7d499d6c92785a0
sha256:930f6e7a1cde805d455683c9e54d452b5a6acc035ec77f86a7d499d6c92785a0: Pulling from envoyproxy/envoy-alpine
Digest: sha256:930f6e7a1cde805d455683c9e54d452b5a6acc035ec77f86a7d499d6c92785a0
Status: Image is up to date for envoyproxy/envoy-alpine:v1.10.0@sha256:930f6e7a1cde805d455683c9e54d452b5a6acc035ec77f86a7d499d6c92785a0
 ---> 0246380e4b70
Step 2/4 : RUN mkdir -p /var/log/envoy
 ---> Using cache
 ---> 3dd1b8f78dc5
Step 3/4 : EXPOSE 9901
 ---> Using cache
 ---> c4d37a0fd727
Step 4/4 : COPY envoy.yaml /etc/envoy/envoy.yaml
 ---> Using cache
 ---> 5e4161911314
Successfully built 5e4161911314
Successfully tagged middlenamesfirst/docker-envoy-proxy:b22fe4cabe
docker-envoy-proxy git:docker-envoy-proxy ❯ make docker-run
docker run -d --name envoy -p 9901:9901 middlenamesfirst/docker-envoy-proxy:b22fe4cabe
9acb8c18efdb9bbd646747103ed9a3d5cac35681bb9448de42ae802702dc7fba
docker-envoy-proxy git:docker-envoy-proxy ❯ docker ps
CONTAINER ID        IMAGE                                            COMMAND                  CREATED             STATUS              PORTS                               NAMES
9acb8c18efdb        middlenamesfirst/docker-envoy-proxy:b22fe4cabe   "/docker-entrypoint.…"   4 seconds ago       Up 3 seconds        0.0.0.0:9901->9901/tcp, 10000/tcp   envoy
docker-envoy-proxy git:docker-envoy-proxy ❯ curl http://localhost:9901/help
admin commands are:
  /: Admin home page
  /certs: print certs on machine
  /clusters: upstream cluster status
  /config_dump: dump current Envoy configs (experimental)
  /contention: dump current Envoy mutex contention stats (if enabled)
  /cpuprofiler: enable/disable the CPU profiler
  /healthcheck/fail: cause the server to fail health checks
  /healthcheck/ok: cause the server to pass health checks
  /heapprofiler: enable/disable the heap profiler
  /help: print out list of admin commands
  /hot_restart_version: print the hot restart compatibility version
  /listeners: print listener addresses
  /logging: query/change logging levels
  /memory: print current allocation/heap usage
  /quitquitquit: exit the server
  /reset_counters: reset all counters to zero
  /runtime: print runtime values
  /runtime_modify: modify runtime values
  /server_info: print server version/status information
  /stats: print server stats
  /stats/prometheus: print server stats in prometheus format
```
Links:
 * https://www.envoyproxy.io/docs/envoy/v1.10.0/operations/admin