### PR TITLE
Add scripts for generating a kubeconfig for a service account

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+envoy-proxy-controller.kubeconfig

--- a/scripts/envoy-proxy-controller-cluster-role-binding.yaml.template
+++ b/scripts/envoy-proxy-controller-cluster-role-binding.yaml.template
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: envoy-proxy-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: envoy-proxy-controller
+  namespace: {{NAMESPACE}}

--- a/scripts/envoy-proxy-controller-service-account.yaml
+++ b/scripts/envoy-proxy-controller-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy-proxy-controller

--- a/scripts/generate-kubeconfig.sh
+++ b/scripts/generate-kubeconfig.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -e # fail immediately on errors
+
+if [ -z "${KUBECONFIG}" ]; then
+  echo "KUBECONFIG variable not defined." >&2
+  exit 1
+fi
+
+if [ -z "${NAMESPACE}" ]; then
+  echo "NAMESPACE variable not defined." >&2
+  exit 1
+fi
+
+if [ -z "${SERVER}" ]; then
+    echo "SERVER variable not defined." >&2
+    exit 1
+fi
+
+kubectl --kubeconfig="${KUBECONFIG}" --namespace="${NAMESPACE}" apply -f ./envoy-proxy-controller-service-account.yaml
+
+< ./envoy-proxy-controller-cluster-role-binding.yaml.template \
+sed "s#{{NAMESPACE}}#${NAMESPACE}#g" | \
+kubectl --kubeconfig="${KUBECONFIG}" --namespace="${NAMESPACE}" apply -f -
+
+SECRET_NAME=$(kubectl --kubeconfig="${KUBECONFIG}" --namespace="${NAMESPACE}" get serviceaccount envoy-proxy-controller -o jsonpath='{.secrets[0].name}')
+CA=$(kubectl --kubeconfig="${KUBECONFIG}" --namespace="${NAMESPACE}" get secret/"${SECRET_NAME}" -o jsonpath='{.data.ca\.crt}')
+TOKEN=$(kubectl --kubeconfig="${KUBECONFIG}" --namespace="${NAMESPACE}" get secret/"${SECRET_NAME}" -o jsonpath='{.data.token}' | base64 --decode)
+
+echo "
+apiVersion: v1
+kind: Config
+clusters:
+- name: default-cluster
+  cluster:
+    certificate-authority-data: ${CA}
+    server: ${SERVER}
+contexts:
+- name: default-context
+  context:
+    cluster: default-cluster
+    namespace: default
+    user: default-user
+current-context: default-context
+users:
+- name: default-user
+  user:
+    token: ${TOKEN}" \
+> envoy-proxy-controller.kubeconfig


### PR DESCRIPTION
This pull requests adds a script for generating a kubeconfig from a service account. The kuberconfig will have the name `envoy-proxy-controller.kubeconfig`. For the time being it will be bound to the `cluster-admin` cluster role. Here's an example of how to produce the kubeconfig:
```
scripts git:service-account-kubeconfig ❯ KUBECONFIG="/Users/mbarry/.kube/configs/mbarry/k8s-1-14-1-do-2-nyc1-1557237159765-kubeconfig.yaml" SERVER="https://a4e72b32-aa81-417e-8701-a63d667045ab.k8s.ondigitalocean.com" NAMESPACE="kube-system" ./generate-kubeconfig.sh
```